### PR TITLE
Clean-ups after walkthrough

### DIFF
--- a/architecture.rst
+++ b/architecture.rst
@@ -13,13 +13,13 @@ NStack is composed of a local CLI toolkit (client) which runs on a user's machin
 * The NStack Cloud, which the NStack team hosts and administers for you on our servers
 * Your local machine for testing
 
-Alternatively, NStack can provide an `.rpm` that can run on your own RHEL-based server. If this is a requirement, please contact us for instructions.
+Alternatively, NStack can provide an `.rpm` that can run on your own server. If this is a requirement, please contact us for instructions.
 
 
 Technologies
 **********
 
-The NStack server is a RHEL-based virtual appliance built on RedHat’s `Project Atomic <https://www.projectatomic.io/>`_ and configured through cloud-init. When a user builds a module with NStack, NStack sends the code to the virtual appliance, packages it, and turns it in a Linux container. When a workflow is written, this is also sent to the server, which takes care of all message routing and orchestration.
+The NStack server is an RPM-based virtual appliance built on Red Hat’s `Project Atomic <https://www.projectatomic.io/>`_ and configured through `cloud-init <https://cloudinit.readthedocs.io/en/latest/>`. When a user builds a module with NStack, NStack sends the code to the virtual appliance, packages it, and turns it into a Linux container. When a workflow is written, this is also sent to the server, which takes care of all message routing and orchestration.
 
 NStack modules can be thought of as serverless microservices which can be used to build cloud dataflows. 
 
@@ -27,7 +27,7 @@ NStack is built using best-of-class technologies, such as:
  - Haskell 
  - rpm-ostree
  - btrfs 
- - sytemd-nspawn
+ - systemd-nspawn
  - d-bus  
 
 

--- a/installation.rst
+++ b/installation.rst
@@ -14,7 +14,7 @@ NStack is platform-agnostic and can run out-of-the-box wherever you can run a vi
 
 For Proof of Concepts, NStack offers a hosted solution. If this is required, please reach out to info@nstack.com.
 
-The virtual appliance can be found on the NStack's `GitHub Releases page <http://github.com/nstackcom/nstack-releases/releases>`_, where is is provided as a ``raw`` or ``qcow2`` image. We also provide an AWS AMI, which can be found under the id of ``ami-53a47245``
+The virtual appliance can be found on the NStack's `GitHub Releases page <http://github.com/nstackcom/nstack-releases/releases>`_, where it is provided as a ``raw`` or ``qcow2`` image. We also provide an AWS AMI, which can be found under the id of ``ami-53a47245``
 
 To launch this AMI to an EC2 instance on your AWS account, you can `click here <https://console.aws.amazon.com/ec2/v2/home?region=us-east-1#LaunchInstanceWizard:ami=ami-53a47245>`_. 
 
@@ -23,7 +23,7 @@ The `NStack Server` is configured using ``cloud-init``, which is supported by ma
 Upgrading
 ==========
 
-The `NStack Server` can be update atomically using `rpm-ostree`. To upgrade to a new release, you can simply run:
+The `NStack Server` can be updated atomically using `rpm-ostree`. To upgrade to a new release, you can simply run:
 
 .. code:: bash
 

--- a/quick_start/module.rst
+++ b/quick_start/module.rst
@@ -36,9 +36,9 @@ A successful ``init`` will have created some files in the directory.
 
 This is the skeleton of an NStack module. ``nstack.yaml`` is the configuration file for your module, and ``service.py`` is where the code of your module lives (in this case, it's a Python class). ``requirements.txt`` and ``setup.py`` are both standard files for configuring Python. 
 
-We're going to be concerned with ``nstack.yaml`` and ``service.py``. For a more in-depth look at all these files, refer to :doc:`Module Structure </reference/module_structure>`
+We're going to be concerned with ``nstack.yaml`` and ``service.py``. For a more in-depth look at all these files, refer to :doc:`Module Structure </reference/module_structure>`.
 
-In ``service.py``, there is a ``Service`` class. This is where we would write the methods we want to use on NStack. It is prefilled it with a sample method, ``numChars``, that counts the number of characters in some text.
+In ``service.py``, there is a ``Service`` class. This is where we would write the methods we want to use on NStack. It is pre-populated with a sample method, ``numChars``, that counts the number of characters in some text.
 
 .. code:: python
 
@@ -102,5 +102,5 @@ We can check that our ``numChars`` method is live by running the suggested ``nst
   ~/demo> nstack list methods
   demo.numChars : Text -> Integer
 
-Now that our ``numChars`` method is live on NStack, we can productionise it by connecting it to input and output data. We do this by attaching it to a event *source* and an event *sink* using NStack's Workflow Language. 
+Now that our ``numChars`` method is live on NStack, we can productionise it by connecting it to input and output data. We do this by attaching it to an event *source* and an event *sink* using NStack's Workflow Language. 
 

--- a/quick_start/workflow.rst
+++ b/quick_start/workflow.rst
@@ -7,7 +7,7 @@ In the previous tutorial, we built and published a Python module using NStack.
 This module had a single method on it, ``numChars``, which counted the number of characters in some text. Although it has been published, we cannot talk to it until we connect it to a `source` and a `sink`.
 In this tutorial, we're going to do this, and we'll be using an HTTP endpoint as a `source`, and NStack's built-in log as a `sink`. When we're finished, we will be able to send some text to an HTTP endpoint, and see the length of the text in our log. 
 
-.. note:: Sources generate data which gets sent to your method, and sinks receive the data which your method outputs. Learn more in :ref:`Concepts <concepts>.`
+.. note:: Sources generate data which gets sent to your method, and sinks receive the data which your method outputs. Learn more in :ref:`Concepts<concepts>`
 
 Let's first refresh ourselves on what the input and output types of our method were by asking NStack:
 

--- a/reference/nstack_toolkit.rst
+++ b/reference/nstack_toolkit.rst
@@ -19,7 +19,7 @@ Having installed the CLI, make sure it's accessible from your path
     $ nstack --version
     > nstack 0.5.4
 
-You can find the list of commands and options available by running,
+You can find the list of commands and options available by running
 
 .. code:: bash
 
@@ -150,7 +150,7 @@ Option          Description
 ``<module>``    The module's name.
 ============    ============
 
-Deletes a module (and thus its methods) from NStack. 
+Deletes a module (and thus its methods) from NStack.
 
 
 ``logs`` 


### PR DESCRIPTION
Mostly typo fixes and small formatting tweaks. Also move away from
specific RHEL references as they are not necessarily strictly accurate
and probably won't please RH.