### PR TITLE
Updates documentation to reflect libnstack type translations

### DIFF
--- a/in_depth_tutorial.rst
+++ b/in_depth_tutorial.rst
@@ -39,7 +39,7 @@ To begin, let's make a new directory called ``Iris.Classify``, ``cd`` into it, a
 .. code:: bash
     
     ~/ $ mkdir Iris.Classify; cd Iris.Classify
-    ~/Iris.Classify/ $ nstack init python
+    ~/Iris.Classify/ $ nstack init --language python
     python module 'Iris.Classify' successfully initialised at ~/Iris.Classify
 
 Next, let's download our training data into this directory so we can use it in our module. We have hosted it for you as a CSV on GitHub.
@@ -66,7 +66,7 @@ Writing our classifier
 ----------------------
  
 Now that we've defined our API, let's jump into our Python module, which lives in ``service.py``.
-We see that NStack has created a class ``Service``. This is where we add the functions for our module. Right now it also has a sample function in it, ``numChars``, which we can remove. 
+We see that NStack has created a class ``Module``. This is where we add the functions for our module. Right now it also has a sample function in it, ``numChars``, which we can remove. 
 
 Let's import the libaries we're using.
 

--- a/languages.rst
+++ b/languages.rst
@@ -13,11 +13,11 @@ Python
 Basic Structure
 ^^^^^^^^^^^^^^^
 
-NStack services in Python inherit from a base class, called ``BaseService`` within the ``nstack`` module::
+NStack services in Python inherit from a base class, called ``Module`` within the ``nstack`` module::
 
   import nstack
 
-  class Service(nstack.BaseService):
+  class Module(nstack.Module):
       def numChars(self, msg):
           return len(msg)
 
@@ -38,7 +38,7 @@ The NStack object lasts for the life-time of the workflow, so if there is any in
 
   import nstack
 
-  class Service(nstack.BaseService):
+  class Module(nstack.Module):
       def startup(self):
           # custom initialisation here
 
@@ -62,78 +62,14 @@ NStack Type    Python Type
 ``Boolean``    ``bool``  
 ``Text``       ``str``   
 Tuple          ``tuple``    
-Struct         ``collections.namedtuple`` *
+Struct         ``dict``
 Array          ``list``                  
 ``[Byte]``     ``bytes``                  
 ``x optional`` ``None`` or ``x``              
-``Json``       a ``json``-encoded string **
+``Json``       a ``json``-encoded string *
 ============== ============================
 
-`\*You can return a normal tuple (see Structs section below)`
-
-`\**Allows you to specify services that either take or receive Json-encoded strings as parameters.`
-
-
-Structs
-"""""""
-
-Given the following example definitions of types in the nstack IDL::
-
-  type URL = Text;
-  type Event = { referrer: URL, target: URL };
-
-When you receive this data into your service method from nstack it will appear as a ``namedtuple`` from the ``collections`` module in the standard-library. eg:
-
-.. code:: python
-
-  nstack.Event = collections.namedtuple("Event", ["referrer", "target"])
-
-This means you can treat the data as both a normal tuple (each field appears in the order it was defined) but also access each field as a property of the value::
-
-  >> input = nstack.Event(("http://www.nstack.com/", "http://demo.nstack.com/")) 
-  >> input.referrer
-  "http://www.nstack.com/"
-  >> input.target
-  "http://demo.nstack.com/" 
-
-
-To construct a struct to return from a Python method we have several options.
-
-For unnamed structs we return a normal tuple, making sure that ordering of the tuple fields are the same as the struct as defined in NStack, e.g.
-
-.. code::
-
-  fun foo : Text -> { referrer: URL, target: URL }
-
-.. code:: python
-
-  return ("http://www.nstack.com/", "http://demo.nstack.com/")
-
-For named structs, we can still return a normal tuple, 
-or construct the return object directly 
-by using an appropriately named function on the ``nstack`` object
-and giving it either a tuple or a dict, e.g.
-
-.. code::
-
-  fun foo : Text -> Event
-
-.. code:: python
-
-  return nstack.Event(dict(referrer="http://www.nstack.com/", target="http://demo.nstack.com/"))
-
-.. code:: python
-
-  return nstack.Event({ "referrer"="http://www.nstack.com/", "target"="http://demo.nstack.com/"})
-
-
-.. code:: python
-
-  return nstack.Event(("http://www.nstack.com/", "http://demo.nstack.com/"))
-
-.. note:: If using a plain tuple, you must still ensure the fields are in the order declared in the ``.nml``
-
-.. note:: It's not currently possible to return a ``namedtuple`` or ``dict`` directly from Python for use as an NStack struct.
+`\*Allows you to specify services that either take or receive Json-encoded strings as parameters.`
 
 R
 -

--- a/quick_start/module.rst
+++ b/quick_start/module.rst
@@ -17,14 +17,14 @@ We want to create a new Python module.
 
 Create a directory called ``Demo`` where you would like to build your module and ``cd`` into that directory using your terminal. NStack uses the name of the directory as the default name of the module
 
-To create a new module, run ``nstack init python``.
+To create a new module, run ``nstack init -l python``.
 You should see the following output confirming that this operation was successful.
 
 .. code:: bash
 
   ~> mkdir Demo.NumChars
   ~> cd Demo.NumChars
-  ~/Demo> nstack init python
+  ~/Demo> nstack init -l python
   python module 'Demo.NumChars:0.0.1-SNAPSHOT' successfully initialised at ~/Demo.NumChars
 
 Because NStack versions your modules, it has given ``Demo.NumChars`` a version number (``0.0.1-SNAPSHOT``). Because the version number has a ``SNAPSHOT`` appended to it, this means NStack allows you to override it every time you build. This is helpful for development, as you do not need to constantly increase the version number. When you deem your module is ready for release, you can remove ``SNAPSHOT`` and NStack will create an immutable version of ``0.0.1``.
@@ -47,11 +47,11 @@ In ``service.py``, there is a ``Service`` class. This is where we write the func
   #!/usr/bin/env python3
   # -*- coding: utf-8 -*-
   """
-  Demo.NumChars Service
+  Demo.NumChars Module
   """
   import nstack
 
-  class Service(nstack.BaseService):
+  class Module(nstack.Module):
       def numChars(self, x):
           return len(x)
 

--- a/quick_start/workflow.rst
+++ b/quick_start/workflow.rst
@@ -33,7 +33,7 @@ Let's create a new directory called ``DemoWorkflow``, ``cd`` into the directory,
 
 .. code :: bash
   
-  ~/DemoWorkflow/ nstack init workflow
+  ~/DemoWorkflow/ nstack init --workflow
   Module 'DemoWorkflow:0.0.1-SNAPSHOT' successfully initialised at /home/nstack/Demo/DemoWorkflow
 
 ``init`` has created a single file, ``module.nml``, which is where we write our workflow module using NStack's scripting language. If we look inside the file, we see that NStack has created an example module for us.

--- a/reference/bigquery_walkthrough.rst
+++ b/reference/bigquery_walkthrough.rst
@@ -52,18 +52,11 @@ and change it to use the BigQuery module as its parent.
 ::
 
   > mkdir CustomerTable; cd CustomerTable
-  > nstack init python nstack/BigQuery:0.2.0
+  > nstack init --framework nstack/BigQuery:0.2.0
 
-The extra parameter to the init command here 
+The ``framework`` parameter to the init command here 
 sets the parent framework module to be BigQuery,
 rather than the default Python image.
-
-As the BigQuery module already has the functionality we need baked into it,
-we can delete the python files that ``init`` creates by default, as we will not be using them:
-
-::
-
-  > rm service.py setup.py requirements.txt
 
 Add your credentials
 --------------------
@@ -165,8 +158,8 @@ Once you have the type declared,
 you can then declare the BigQuery action you wish to take
 as an NStack function.
 
-Open the ``module.nml`` file and remove the example function ``numChars``.
-Instead you must write a function definition for one or more of the 
+Create a ``module.nml`` file and add in the boilerplate ``module CustomerTable:0.0.1-SNAPSHOT where``.
+Next you must write a function definition for one or more of the 
 ``runQuery``, ``downloadData`` or ``uploadData`` functions that exist in the BigQuery parent image.
 If downloading or uploading,
 you declare them to use a list of the data type you just declared


### PR DESCRIPTION
Hey @lanthias 

This updates some of the docs for (a) the changes for how Python types correspond to nstack types and (b) some changes in how module initialisation works.

@mands mentioned I should check in with you if it made sense to merge this. I think because the release is behind at least the change to the type correspondence (and possibly the module initialisation stuff) but I'm not 100% sure.